### PR TITLE
Revert compat for Distributions to 0.25

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ScientificTypes"
 uuid = "321657f4-b219-11e9-178b-2701a2544e81"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 CategoricalArrays = "0.8, 0.9, 0.10"
 ColorTypes = "0.9, 0.10, 0.11"
-Distributions = "0.24,0.25"
+Distributions = "0.25"
 PersistenceDiagramsBase = "0.1"
 PrettyTables = "1"
 ScientificTypesBase = "2.1"


### PR DESCRIPTION
I mistakenly overlooked fact that 0.25 is needed b/s it defines `ArrayLikeVariate`, so this is a bug fix.