### PR TITLE
fix issue #146

### DIFF
--- a/src/convention/scitype.jl
+++ b/src/convention/scitype.jl
@@ -25,8 +25,8 @@ function ST.scitype(c::Cat, ::DefaultConvention)
     return ifelse(c.pool.ordered, OrderedFactor{nc}, Multiclass{nc})
 end
 
-const CatArrOrSub{T,N} =
-    Union{CategoricalArray{T,N},SubArray{<:Any,<:Any,<:CategoricalArray{T,N}}}
+const CatArrOrSub{T, N} =
+    Union{CategoricalArray{T, N}, SubArray{T, N, <:CategoricalArray}}
 
 function ST.scitype(A::CatArrOrSub{T,N}, ::DefaultConvention) where {T,N}
     nlevels = length(levels(A))

--- a/test/type_tests.jl
+++ b/test/type_tests.jl
@@ -42,6 +42,11 @@ Tables.columns(t::MySchemalessTable) = t
     X2 = MySchemalessTable(rand(3), rand(3))
     s2 = schema(X2)
     @test s2 === nothing
+
+    #issue 146
+    X = Tables.table(coerce(rand("abc", 5, 3), Multiclass))
+    @test scitype(X) === Table{AbstractVector{Multiclass{3}}}
+
 end
 
 # TODO: re-instate when julia 1.0 is no longer LTS release:


### PR DESCRIPTION
closes #146 
```julia
julia> X = Tables.table(coerce(rand("abc", 5, 3), Multiclass))
Tables.MatrixTable{CategoricalArrays.CategoricalMatrix{Char, UInt32, Char, CategoricalArrays.CategoricalValue{Char, UInt32}, Union{}}} with 5 rows, 3 columns, and schema:
 :Column1  CategoricalArrays.CategoricalValue{Char, UInt32}
 :Column2  CategoricalArrays.CategoricalValue{Char, UInt32}
 :Column3  CategoricalArrays.CategoricalValue{Char, UInt32}

julia> scitype(X)
Table{AbstractVector{Multiclass{3}}}

```