### PR TITLE
Exclude certain kinds of dictionary tables from being interpreted as tables

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -134,17 +134,20 @@ Type `T`        | `scitype(x)` for `x::T`           | package/module required
 `AbstractArray{<:Gray,2}` | `GrayImage{W,H}` where `(W, H) = size(x)`                                   | ColorTypes.jl
 `AbstractArrray{<:AbstractRGB,2}` | `ColorImage{W,H}` where `(W, H) = size(x)`                                  | ColorTypes.jl
 `PersistenceDiagram` | `PersistenceDiagram` | PersistenceDiagramsBase
-(*) any table type `T` supported by Tables.jl | `Table{K}` where `K=Union{column_scitypes...}`                      | Tables.jl
+(*) any table type `T` | `Table{K}` where `K=Union{column_scitypes...}`                      | Tables.jl
 † `CorpusLoaders.TaggedWord` | `Annotated{Textual}` | CorpusLoaders.jl
 † `CorpusLoaders.Document{AbstractVector{Q}}` | `Annotated{AbstractVector{Scitype(Q)}}` | CorpusLoaders.jl
 † `AbstractDict{<:AbstractString,<:Integer}` | `Multiset{Textual}` | 
 † `AbstractDict{<:TaggedWord,<:Integer}` | `Multiset{Annotated{Textual}}` | CorpusLoaders.jl
 
-(*) In Tables.jl version 1.8 abstract dictionaries with `String` keys, and abstract
-vectors of dictionaries with `String` keys became tables, according to the value of
-`Tables.istable`. (Previously only symbolic keys had that interpretation.) This change was
-breaking for ScientificTypes.jl (see `Multiset{Textual}` above) which accordingly
-continues to regard these objects as non-tabular.
+(*) More precisely, any object `X` for which `Tables.istable(X) == true` will have
+`sctiype(X) = Table{K}`, where `K` is the union of the column scitypes, with the following
+exceptions: abstract dictionaries with `AbstractString` keys, and abstract vectors of
+abstract dictionaries with `AbstractString` keys are not considered tables by
+ScientificTypes.jl. Prior to Tables.jl 1.8, one had `Tables.istable(X) == false` for these
+objects but in releases 1.8 and 1.10, this behaviour changed. These changes were breaking
+for ScientificTypes.jl, which has accordingly enforced the old behaviour, as far as
+`scitype` is concerned.
 
 † *Experimental* and subject to change in new minor or patch release
 
@@ -322,7 +325,7 @@ schema(data)
 scitype(data)
 ```
 
-Similarly, any table implementing the Tables interface has scitype
+Similarly, any table (see (*) above for the definition) has scitype
 `Table{K}`, where `K` is the union of the scitypes of its columns.
 
 Table scitypes are useful for dispatch and type checks, as shown here,

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -134,11 +134,17 @@ Type `T`        | `scitype(x)` for `x::T`           | package/module required
 `AbstractArray{<:Gray,2}` | `GrayImage{W,H}` where `(W, H) = size(x)`                                   | ColorTypes.jl
 `AbstractArrray{<:AbstractRGB,2}` | `ColorImage{W,H}` where `(W, H) = size(x)`                                  | ColorTypes.jl
 `PersistenceDiagram` | `PersistenceDiagram` | PersistenceDiagramsBase
-any table type `T` supported by Tables.jl | `Table{K}` where `K=Union{column_scitypes...}`                      | Tables.jl
+(*) any table type `T` supported by Tables.jl | `Table{K}` where `K=Union{column_scitypes...}`                      | Tables.jl
 † `CorpusLoaders.TaggedWord` | `Annotated{Textual}` | CorpusLoaders.jl
 † `CorpusLoaders.Document{AbstractVector{Q}}` | `Annotated{AbstractVector{Scitype(Q)}}` | CorpusLoaders.jl
 † `AbstractDict{<:AbstractString,<:Integer}` | `Multiset{Textual}` | 
 † `AbstractDict{<:TaggedWord,<:Integer}` | `Multiset{Annotated{Textual}}` | CorpusLoaders.jl
+
+(*) In Tables.jl version 1.8 abstract dictionaries with `String` keys, and abstract
+vectors of dictionaries with `String` keys became tables, according to the value of
+`Tables.istable`. (Previously only symbolic keys had that interpretation.) This change was
+breaking for ScientificTypes.jl (see `Multiset{Textual}` above) which accordingly
+continues to regard these objects as non-tabular.
 
 † *Experimental* and subject to change in new minor or patch release
 
@@ -151,7 +157,6 @@ Here `nlevels(x) = length(levels(x.pool))`.
 - `Image{W,H}`, `GrayImage{W,H}` and `ColorImage{W,H}` are all parameterized by the image width and height dimensions, `(W, H)`.
 - `Sampleable{K}` and `Density{K} <: Sampleable{K}` are parameterized by the sample space scitype.
 - On objects for which the default convention has nothing to say, the `scitype` function returns `Unknown`.
-- In Tables.jl version 1.8 abstract dictionaries with `String` keys, and abstract vectors of dictionaries with `String` keys became tables, according to the value of `Tables.istable`. (Previously only symbolic keys had that interpretation.) This change was breaking for ScientificTypes.jl (see `Multiset{Textual}` above) which accordingly continues to regard these objects as non-tabular. 
 
 ### Special note on binary data
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -149,11 +149,9 @@ Here `nlevels(x) = length(levels(x.pool))`.
 - We regard the built-in Julia types `Missing` and `Nothing` as scientific types.
 - `Finite{N}`, `Multiclass{N}` and `OrderedFactor{N}` are all parameterized by the number of levels `N`. We export the alias `Binary = Finite{2}`.
 - `Image{W,H}`, `GrayImage{W,H}` and `ColorImage{W,H}` are all parameterized by the image width and height dimensions, `(W, H)`.
-- `Sampleable{K}` andb
-`Density{K} <: Sampleable{K}` are parameterized by the sample space scitype.
-- On objects for which the default convention has nothing to say, the
-  `scitype` function returns `Unknown`.
-
+- `Sampleable{K}` and `Density{K} <: Sampleable{K}` are parameterized by the sample space scitype.
+- On objects for which the default convention has nothing to say, the `scitype` function returns `Unknown`.
+- In Tables.jl version 1.8 abstract dictionaries with `String` keys, and abstract vectors of dictionaries with `String` keys became tables, according to the value of `Tables.istable`. (Previously only symbolic keys had that interpretation.) This change was breaking for ScientificTypes.jl (see `Multiset{Textual}` above) which accordingly continues to regard these objects as non-tabular. 
 
 ### Special note on binary data
 

--- a/src/ScientificTypes.jl
+++ b/src/ScientificTypes.jl
@@ -1,4 +1,4 @@
-module ScientificTypes 
+module ScientificTypes
 
 # Dependencies
 using Reexport
@@ -27,11 +27,24 @@ const SCHEMA_SPECIALIZATION_THRESHOLD = Tables.SCHEMA_SPECIALIZATION_THRESHOLD
 
 #---------------------------------------------------------------------------------------
 # Define convention
+
 struct DefaultConvention <: Convention end
 const CONV = DefaultConvention()
+
 # -------------------------------------------------------------
 # vtrait function, returns either `Val{:table}()` or `Val{:other}()`
-vtrait(X) = Val{ifelse(Tables.istable(X), :table, :other)}()
+
+# To address https://github.com/JuliaData/Tables.jl/issues/306:
+const DictColumnsWithStringKeys = AbstractDict{K, V} where {
+    K <: String,
+    V <: AbstractVector
+}
+const DictRowsWithStringKeys = AbstractVector{T} where T <: AbstractDict{String}
+_istable(::DictColumnsWithStringKeys) = false
+_istable(::DictRowsWithStringKeys) = false
+_istable(something_else) = Tables.istable(something_else)
+
+vtrait(X) = Val{ifelse(_istable(X), :table, :other)}()
 
 # -------------------------------------------------------------
 # Includes

--- a/src/ScientificTypes.jl
+++ b/src/ScientificTypes.jl
@@ -36,10 +36,12 @@ const CONV = DefaultConvention()
 
 # To address https://github.com/JuliaData/Tables.jl/issues/306:
 const DictColumnsWithStringKeys = AbstractDict{K, V} where {
-    K <: String,
+    K <: AbstractString,
     V <: AbstractVector
 }
-const DictRowsWithStringKeys = AbstractVector{T} where T <: AbstractDict{String}
+const DictRowsWithStringKeys = AbstractVector{T} where {
+T <: AbstractDict{<:AbstractString}
+}
 _istable(::DictColumnsWithStringKeys) = false
 _istable(::DictRowsWithStringKeys) = false
 _istable(something_else) = Tables.istable(something_else)

--- a/test/convention/scitype.jl
+++ b/test/convention/scitype.jl
@@ -65,10 +65,10 @@ end
     @test scitype(Any[categorical(1:4)...]) == Vec{Multiclass{4}}
     @test scitype(categorical([1, missing, 3])) ==
         Vec{Union{Multiclass{2},Missing}}
-    
+
         a = ["aa", "bb", "aa", "bb"] |> categorical
     @test scitype(a[1]) == Multiclass{2}
- 
+
     # NOTE: the slice here does not contain missings but the machine type
     # still contains a missing so the scitype remains with a missing
     @test scitype(categorical([1, missing, 3])[1:1]) ==
@@ -169,7 +169,7 @@ end
     ) == r
     # ExtremelyWide row oriented table
     @test ST._rows_scitype(
-        rows, 
+        rows,
         Tables.Schema(
             Tables.columnnames(iterate(rows, 1)[1]),
             (Int, Int, CategoricalValue{Char, UInt32}, Float64);
@@ -177,7 +177,7 @@ end
         )
     ) == r
 
-    # test schema for column oreinted tables with number of columns 
+    # test schema for column oreinted tables with number of columns
     # exceeding COLS_SPECIALIZATION_THRESHOLD.
     nt = NamedTuple{
             Tuple(Symbol("x$i") for i in Base.OneTo(ST.COLS_SPECIALIZATION_THRESHOLD + 1))
@@ -189,6 +189,12 @@ end
     #issue 146
     X = Tables.table(coerce(rand("abc", 5, 3), Multiclass))
     @test scitype(X) === Table{AbstractVector{Multiclass{3}}}
+
+    # dictionaries are not tables:
+    @test !(scitype(Dict("a" => [1, 2, 3], "b" => [4, 5, 6])) <: Table)
+
+    # vectors of dictionaries are not tables:
+    @test !(scitype([Dict("a" => 1), Dict("a" => 2)]) <: Table)
 end
 
 # TODO: re-instate when julia 1.0 is no longer LTS release:

--- a/test/convention/scitype.jl
+++ b/test/convention/scitype.jl
@@ -191,10 +191,13 @@ end
     @test scitype(X) === Table{AbstractVector{Multiclass{3}}}
 
     # dictionaries are not tables:
+    _s(str) = SubString(str, 1)
     @test !(scitype(Dict("a" => [1, 2, 3], "b" => [4, 5, 6])) <: Table)
+    @test !(scitype(Dict(_s("a") => [1, 2, 3], _s("b") => [4, 5, 6])) <: Table)
 
     # vectors of dictionaries are not tables:
     @test !(scitype([Dict("a" => 1), Dict("a" => 2)]) <: Table)
+    @test !(scitype([Dict(_s("a") => 1), Dict(_s("a") => 2)]) <: Table)
 end
 
 # TODO: re-instate when julia 1.0 is no longer LTS release:

--- a/test/schema.jl
+++ b/test/schema.jl
@@ -89,7 +89,7 @@ end
         z = categorical(collect("asdfa")),
         w = rand(5)
      )
-     s = schema(X)
+    s = schema(X)
     @test s.scitypes == (Continuous, Count, Multiclass{4}, Continuous)
     @test s.types == (Float64, Int64, CategoricalValue{Char,UInt32}, Float64)
 


### PR DESCRIPTION
This PR will:

- Restore behaviour [broken](https://github.com/JuliaData/Tables.jl/issues/306) by Tables 1.8 by explicitly excluding the following objects from the ScientificTypes.jl definition of "table":
  - Abstract dicts with `String` keys
  - Abstract vectors of abstract dicts with `String` keys
- Improve the `scitype` docstring (#185)